### PR TITLE
AT 12.02.05 | Header > Redirect from "Build History" page to the homepage

### DIFF
--- a/src/test/java/HeaderTest.java
+++ b/src/test/java/HeaderTest.java
@@ -120,5 +120,21 @@ public class HeaderTest extends BaseTest {
                 getDriver().findElement(By.tagName("h1")).getText(),
                 "Credentials");
     }
+
+    @Test
+    public void testVerifyRedirectToManePage()  {
+
+        getDriver().findElement(
+                By.linkText("Build History")).click();
+
+        Assert.assertEquals(getDriver().findElement(By.tagName("h1")).getText(),
+                "Build History of Jenkins");
+
+        getDriver().findElement(By.id("jenkins-name-icon")).click();
+
+        Assert.assertEquals(getDriver().findElement(By.tagName("h1")).getText(),
+                "Welcome to Jenkins!");
+
+    }
 }
 


### PR DESCRIPTION
Test VerifyRedirectToManePage added and refactor the method

[AT] - https://trello.com/c/WfeJPQ3P/474-at-000000-new-item-sub-item
[TC] - https://trello.com/c/8cKwypDr/270-tc-120205-header-logo-name-icon-verify-that-user-redirect-from-build-history-page-to-the-homepage-by-clicking-the-name-icon
[US] -https://trello.com/c/Mvn2nY2Q/102-us-1202-header-logo-name-icon