### PR TITLE
RF|TestUtils -> scrollToElement

### DIFF
--- a/src/test/java/runner/TestUtils.java
+++ b/src/test/java/runner/TestUtils.java
@@ -20,8 +20,11 @@ public class TestUtils {
     }
 
     public static void scrollToElement(WebDriver driver, WebElement element) {
-        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
+        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView();", element);
+    }
 
+    public static void scrollToElement_PlaceInCenter(WebDriver driver, WebElement element) {
+        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
     }
 
     public static class ExpectedConditions {

--- a/src/test/java/runner/TestUtils.java
+++ b/src/test/java/runner/TestUtils.java
@@ -20,7 +20,7 @@ public class TestUtils {
     }
 
     public static void scrollToElement(WebDriver driver, WebElement element) {
-        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView();", element);
+        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
 
     }
 

--- a/src/test/java/runner/TestUtils.java
+++ b/src/test/java/runner/TestUtils.java
@@ -23,7 +23,7 @@ public class TestUtils {
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView();", element);
     }
 
-    public static void scrollToElement_PlaceInCenter(WebDriver driver,  WebElement element) {
+    public static void scrollToElement_PlaceInCenter(WebDriver driver, WebElement element) {
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
     }
 

--- a/src/test/java/runner/TestUtils.java
+++ b/src/test/java/runner/TestUtils.java
@@ -23,7 +23,7 @@ public class TestUtils {
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView();", element);
     }
 
-    public static void scrollToElement_PlaceInCenter(WebDriver driver, WebElement element) {
+    public static void scrollToElement_PlaceInCenter(WebDriver driver,  WebElement element) {
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
     }
 


### PR DESCRIPTION
Added a parameter that moves the scrolled element into the middle of the page. Without it the scrolled element may be hidden by the bottom ribbon with the Save/Cancel buttons