### PR TITLE
RF | NewItemCreatePipline > testCreatePipelineWithoutName and testEditPipelineDescription

### DIFF
--- a/src/test/java/NewItemCreatePipelineTest.java
+++ b/src/test/java/NewItemCreatePipelineTest.java
@@ -58,14 +58,6 @@ public class NewItemCreatePipelineTest extends BaseTest {
     }
 
     @Test
-    public void testCreatePipelineWithoutName() {
-        setJobPipeline("");
-
-        Assert.assertEquals(getDriver().findElement(By.id("itemname-required")).getText(),
-                "» This field cannot be empty, please enter a valid name");
-    }
-
-    @Test
     public void testCreateNewItemWithoutChooseAnyFolder(){
         setJobPipeline("");
 
@@ -269,7 +261,7 @@ public class NewItemCreatePipelineTest extends BaseTest {
                 .clickPipelineProjectName()
                 .editDescription(newDescription)
                 .clickSaveButton()
-                .getDescription("textContent");
+                .getDescription();
 
         Assert.assertEquals(actualDescription, newDescription);
     }

--- a/src/test/java/NewItemTest.java
+++ b/src/test/java/NewItemTest.java
@@ -76,4 +76,22 @@ public class NewItemTest extends BaseTest {
             Assert.assertEquals(actualErrorMessage, "No name is specified");
         }
     }
+
+    @Test
+    public void testCreateItemsWithoutName() {
+        int itemsListSize = new HomePage((getDriver()))
+                .clickNewItem()
+                .getItemsListSize();
+
+        for (int i = 0; i < itemsListSize; i++) {
+
+            String actualErrorMessage = new NewItemPage((getDriver()))
+                    .rootMenuDashboardLinkClick()
+                    .clickNewItem()
+                    .setItem(i)
+                    .getEmptyNameErrorMessage();
+
+            Assert.assertEquals(actualErrorMessage,"» This field cannot be empty, please enter a valid name");
+        }
+    }
 }

--- a/src/test/java/model/NewItemPage.java
+++ b/src/test/java/model/NewItemPage.java
@@ -45,6 +45,9 @@ public class NewItemPage extends HomePage {
     @FindBy(css = "div#itemname-invalid" )
     private WebElement unsafeCharErrorMessage;
 
+    @FindBy(css = "#itemname-required")
+    private WebElement emptyNameErrorMessage;
+
 
     public NewItemPage(WebDriver driver) {
         super(driver);
@@ -100,6 +103,13 @@ public class NewItemPage extends HomePage {
         return new CreateItemErrorPage(getDriver());
     }
 
+    public NewItemPage setItem(int index) {
+        getAction().scrollByAmount(0, 250).perform();
+        itemsList.get(index).click();
+
+        return this;
+    }
+
     public int getItemsListSize() {
         getWait(5).until(ExpectedConditions.visibilityOfAllElements(itemsList));
         return itemsList.size();
@@ -136,5 +146,10 @@ public class NewItemPage extends HomePage {
 
     public String getUnsafeCharErrorMessageText() {
         return unsafeCharErrorMessage.getAttribute("textContent");
+    }
+
+    public String getEmptyNameErrorMessage() {
+
+        return emptyNameErrorMessage.getAttribute("textContent");
     }
 }

--- a/src/test/java/model/PipelineProjectPage.java
+++ b/src/test/java/model/PipelineProjectPage.java
@@ -36,8 +36,8 @@ public class PipelineProjectPage extends BasePage{
         return this;
     }
 
-    public String getDescription(String name) {
+    public String getDescription() {
 
-        return description.getAttribute(name);
+        return description.getAttribute("textContent");
     }
 }


### PR DESCRIPTION
moved input attribute name from testEditPipelineDescription inside method getDescription()

moved testCreatePipelineWithoutName from NewItemCreatePipelineTest class to NewItemTest class and make to check for all items

created to NewItemPage:
- getEmptyNameErrorMessage()
- setItem(int index)

added locator emptyNameErrorMessage to NewItemPage