### PR TITLE
ERR | FreestyleProjectTest> testConfigureSourceCodeByGIT

### DIFF
--- a/src/test/java/model/GlobalToolConfigurationPage.java
+++ b/src/test/java/model/GlobalToolConfigurationPage.java
@@ -53,6 +53,7 @@ public class GlobalToolConfigurationPage extends BasePage {
     }
 
     public String getErrorAreaText() {
+
         return getWait(5).until(ExpectedConditions.visibilityOf(errorArea)).getText();
     }
 }

--- a/src/test/java/model/GlobalToolConfigurationPage.java
+++ b/src/test/java/model/GlobalToolConfigurationPage.java
@@ -36,7 +36,7 @@ public class GlobalToolConfigurationPage extends BasePage {
 
     public GlobalToolConfigurationPage setFirstMavenTitleField(String name) {
         TestUtils.scrollToEnd(getDriver());
-        TestUtils.scrollToElement(getDriver(), mavenTitleFields.get(0));
+        getAction().scrollToElement(mavenTitleFields.get(0)).moveToElement(mavenTitleFields.get(0)).perform();
         getWait(5).until(TestUtils.ExpectedConditions.elementIsNotMoving(mavenTitleFields.get(0)));
         getWait(5).until(ExpectedConditions.elementToBeClickable(mavenTitleFields.get(0))).click();
         mavenTitleFields.get(0).sendKeys(name);

--- a/src/test/java/model/freestyle/FreestyleProjectConfigPage.java
+++ b/src/test/java/model/freestyle/FreestyleProjectConfigPage.java
@@ -234,6 +234,7 @@ public class FreestyleProjectConfigPage extends BaseConfigPage<FreestyleProjectS
     }
 
     public FreestyleProjectConfigPage selectSourceCodeManagementGIT() {
+        getWait(5).until(TestUtils.ExpectedConditions.elementIsNotMoving(radioGitButton));
         getAction()
                 .scrollToElement(radioGitButton)
                 .moveToElement(radioGitButton)

--- a/src/test/java/tests/FreestyleProjectTest.java
+++ b/src/test/java/tests/FreestyleProjectTest.java
@@ -273,7 +273,6 @@ public class FreestyleProjectTest extends BaseTest {
         Assert.assertTrue(page.isBooleanParameterDefaultOn());
     }
 
-    @Ignore
     @Test(dependsOnMethods = "testConfigureJobAsParameterized")
     public void testConfigureSourceCodeByGIT() {
         final String repositoryURL = "https://github.com/RedRoverSchool/JenkinsQA_05.git";


### PR DESCRIPTION
ERR | FreestyleProjectTest> testConfigureSourceCodeByGIT():

- Fix  ERR in `testConfigureSourceCodeByGIT()`;
- Fix ERR in `setFirstMavenTitleField()` because CI crushed.