### PR TITLE
ERR | FooterComponentTest > testFooterLinkJenkinsRedirectToPage

### DIFF
--- a/src/test/java/model/ExternalJenkinsPage.java
+++ b/src/test/java/model/ExternalJenkinsPage.java
@@ -6,18 +6,12 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 public class ExternalJenkinsPage extends FooterComponent {
-    @FindBy(xpath = "//a[@class='navbar-brand']")
-    private WebElement textJenkins;
 
     @FindBy(xpath = "//h1")
     private WebElement textHeaderJenkins;
 
     public ExternalJenkinsPage(WebDriver driver) {
         super(driver);
-    }
-
-    public String getTextJenkins() {
-        return textJenkins.getText();
     }
 
     public String getHeaderText() {


### PR DESCRIPTION
ERR | FooterComponentTest > testFooterLinkJenkinsRedirectToPage

Changed the external page, so we getting errors.  In previous PR was change the assert in failed test. 
In this PR deleted not actual WebElement and method.