### PR TITLE
RF| add DeletePage to FolderOneTest and FolderTest

### DIFF
--- a/src/test/java/model/DeletePage.java
+++ b/src/test/java/model/DeletePage.java
@@ -22,7 +22,7 @@ public class DeletePage extends BasePage {
         return new ManageUsersPage(getDriver());
     }
 
-    public HomePage clickYesButtonDeleteListView() {
+    public HomePage clickYesButtonDeleteReturnHome() {
         yesButton.click();
 
         return new HomePage(getDriver());
@@ -34,7 +34,7 @@ public class DeletePage extends BasePage {
         return new MyViewsPage(getDriver());
     }
 
-    public FolderStatusPage clickYesButtonDeleteItem() {
+    public FolderStatusPage clickYesButtonDeleteReturnFolderStatus() {
         yesButton.click();
 
         return new FolderStatusPage(getDriver());

--- a/src/test/java/model/HomePage.java
+++ b/src/test/java/model/HomePage.java
@@ -229,11 +229,11 @@ public class HomePage extends BreadcrumbsComponent {
         return new PipelineStatusPage(getDriver());
     }
 
-    public FolderConfigPage clickDeleteDropDownMenu() {
+    public DeletePage clickDeleteDropDownMenu() {
         getWait(3).until(ExpectedConditions.elementToBeClickable(deleteButtonInDropDownMenu));
         deleteButtonInDropDownMenu.click();
 
-        return new FolderConfigPage(getDriver());
+        return new DeletePage(getDriver());
     }
 
     public HomePage clickJobDropDownMenu(String name) {

--- a/src/test/java/model/folder/FolderStatusPage.java
+++ b/src/test/java/model/folder/FolderStatusPage.java
@@ -1,5 +1,6 @@
 package model.folder;
 
+import model.DeletePage;
 import model.RenameItemPage;
 import model.base.BaseStatusPage;
 import model.freestyle.FreestyleProjectStatusPage;
@@ -109,10 +110,10 @@ public class FolderStatusPage extends BaseStatusPage<FolderStatusPage> {
         return new NewItemPage(getDriver());
     }
 
-    public FolderStatusPage clickDeleteFolder() {
+    public DeletePage clickDeleteFolder() {
         deleteFolder.click();
 
-        return new FolderStatusPage(getDriver());
+        return new DeletePage(getDriver());
     }
 
     public List<String> getTopMenueLinkText() {

--- a/src/test/java/tests/FolderOneTest.java
+++ b/src/test/java/tests/FolderOneTest.java
@@ -92,7 +92,7 @@ public class FolderOneTest extends BaseTest {
         HomePage homePage = new HomePage(getDriver())
                 .clickFolder(RANDOM_NAME_1)
                 .clickDeleteFolder()
-                .clickSubmitButton()
+                .clickYesButtonDeleteReturnHome()
                 .clickDashboard();
 
         Assert.assertFalse(homePage.getJobNamesList().contains(RANDOM_NAME_1));
@@ -151,7 +151,7 @@ public class FolderOneTest extends BaseTest {
         HomePage homePage = new HomePage(getDriver())
                 .clickJobDropdownMenu(RANDOM_NAME_1 + "NEW")
                 .clickDeleteDropDownMenu()
-                .clickSubmitDeleteProject();
+                .clickYesButtonDeleteReturnHome();
 
         Assert.assertFalse(homePage.getJobNamesList().contains(RANDOM_NAME_1 + "NEW"));
     }
@@ -273,7 +273,7 @@ public class FolderOneTest extends BaseTest {
                 .clickFolder(RANDOM_NAME_1)
                 .clickMultibranchPipeline(RANDOM_MULTIBRANCH_PIPELINE_NAME)
                 .clickDeleteMultibranchPipeline()
-                .clickYesButtonDeleteItem();
+                .clickYesButtonDeleteReturnFolderStatus();
 
         Assert.assertEquals(folderStatusPage.getNameText(), RANDOM_NAME_1);
         Assert.assertNotNull(folderStatusPage.getEmptyStateBlock());

--- a/src/test/java/tests/FolderTest.java
+++ b/src/test/java/tests/FolderTest.java
@@ -104,7 +104,7 @@ public class FolderTest extends BaseTest {
                 .clickDashboard()
                 .clickJob(DISPLAY_RANDOM_NAME)
                 .clickDeleteFolder()
-                .clickSubmitButton()
+                .clickYesButtonDeleteReturnFolderStatus()
                 .getNameText();
 
         Assert.assertEquals(pageHeaderText, "Welcome to Jenkins!");
@@ -272,7 +272,7 @@ public class FolderTest extends BaseTest {
                 .clickDashboard()
                 .clickJobDropDownMenu(FOLDER_RANDOM_NAME_1)
                 .clickDeleteDropDownMenu()
-                .clickSubmitDeleteProject()
+                .clickYesButtonDeleteReturnHome()
                 .getHeaderText();
 
         Assert.assertEquals(welcomeJenkinsHeader, "Welcome to Jenkins!");

--- a/src/test/java/tests/ListViewTest.java
+++ b/src/test/java/tests/ListViewTest.java
@@ -85,7 +85,7 @@ public class ListViewTest extends BaseTest {
         List<String> viewList = new HomePage(getDriver())
                 .clickView(RANDOM_LIST_VIEW_NAME)
                 .clickDeleteViewItem()
-                .clickYesButtonDeleteListView()
+                .clickYesButtonDeleteReturnHome()
                 .getViewList();
 
         Assert.assertFalse(viewList.contains(RANDOM_LIST_VIEW_NAME));


### PR DESCRIPTION
1. Methods changed with the addition of the DeletePage in HomePage, FolderStatusPage, FolderTest and FolderOneTest.
2. The DeletePage has renamed the methods: clickYesButtonDeleteListView -> clickYesButtonDeleteReturnHome, 
clickYesButtonDeleteItem -> clickYesButtonDeleteReturnFolderStatus.


    https://trello.com/c/5vDxHKWP/1153-rf-add-deletepage-to-folderonetest-and-foldertest