### PR TITLE
RF | FooterComponentTest > testFooterLinkJenkinsIsClickable

### DIFF
--- a/src/test/java/model/ManageJenkinsPage.java
+++ b/src/test/java/model/ManageJenkinsPage.java
@@ -1,5 +1,6 @@
 package model;
 
+import model.base.FooterComponent;
 import model.base.MainBasePage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -66,12 +67,12 @@ public class ManageJenkinsPage extends MainBasePage {
         return new PluginManagerPage(getDriver());
     }
 
-    public ExternalJenkinsPage moveToJenkinsVersion() {
+    public FooterComponent moveToJenkinsVersion() {
         scrollToEnd(getDriver());
         WebElement linkJenkins = new HomePage(getDriver()).getFooter().getJenkinsFooterLink();
         getAction().pause(500).moveToElement(getWait(3).until(ExpectedConditions.elementToBeClickable(linkJenkins)))
                 .perform();
       
-        return new ExternalJenkinsPage(getDriver());
+        return new FooterComponent(getDriver());
     }
 }

--- a/src/test/java/model/ManageJenkinsPage.java
+++ b/src/test/java/model/ManageJenkinsPage.java
@@ -66,14 +66,9 @@ public class ManageJenkinsPage extends HeaderComponent {
         return new PluginManagerPage(getDriver());
     }
 
-    public ManageJenkinsPage clickManageJenkins() {
-        manageJenkins.click();
+    public ExternalJenkinsPage moveToJenkinsVersion() {
         scrollToEnd(getDriver());
-        return this;
-    }
-
-    public ExternalJenkinsPage moveForClinkOnLink() {
-        WebElement linkJenkins = new ExternalJenkinsPage(getDriver()).getJenkinsLink();
+        WebElement linkJenkins = new ExternalJenkinsPage(getDriver()).getJenkinsFooterLink();
         getAction().pause(500).moveToElement(getWait(3).until(ExpectedConditions.elementToBeClickable(linkJenkins)))
                 .perform();
         return new ExternalJenkinsPage(getDriver());

--- a/src/test/java/model/base/FooterComponent.java
+++ b/src/test/java/model/base/FooterComponent.java
@@ -13,7 +13,7 @@ public abstract class FooterComponent extends BasePage {
     private WebElement restApi;
 
     @FindBy(xpath = "//a[@href='https://www.jenkins.io/']")
-    private WebElement jenkinsLink;
+    private WebElement jenkinsFooterLink;
 
     @FindBy(id = "footer")
     private WebElement footer;
@@ -29,7 +29,7 @@ public abstract class FooterComponent extends BasePage {
     }
 
     public ExternalJenkinsPage clickJenkinsVersion() {
-        jenkinsLink.click();
+        jenkinsFooterLink.click();
         ArrayList<String> tabs = new ArrayList<>(getDriver().getWindowHandles());
         getDriver().switchTo().window(tabs.get(1));
         return new ExternalJenkinsPage(getDriver());
@@ -39,7 +39,7 @@ public abstract class FooterComponent extends BasePage {
         return footer.isDisplayed();
     }
 
-    public WebElement getJenkinsLink() {
-        return jenkinsLink;
+    public WebElement getJenkinsFooterLink() {
+        return jenkinsFooterLink;
     }
 }

--- a/src/test/java/tests/FooterComponentTest.java
+++ b/src/test/java/tests/FooterComponentTest.java
@@ -1,9 +1,6 @@
 package tests;
 
-import model.ExternalJenkinsPage;
-import model.ManageJenkinsPage;
-import model.RestApiPage;
-import model.XmlPage;
+import model.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import runner.BaseTest;
@@ -43,14 +40,14 @@ public class FooterComponentTest extends BaseTest {
                 + "style information associated with it. The document tree is shown below.");
     }
 
-    @Test()
+    @Test
     public void testFooterLinkJenkinsIsClickable() {
-        String headerJenkins = new ManageJenkinsPage(getDriver())
+        String externalJenkinsPageHeader = new HomePage(getDriver())
                 .clickManageJenkins()
-                .moveForClinkOnLink()
+                .moveToJenkinsVersion()
                 .clickJenkinsVersion()
                 .getHeaderText();
 
-        Assert.assertEquals(headerJenkins,"Jenkins");
+        Assert.assertEquals(externalJenkinsPageHeader,"Jenkins");
     }
 }


### PR DESCRIPTION
refactor testFooterLinkJenkinsIsClickable()
delete clickManageJenkins() from ManageJenkinsPage (use instead clickManageJenkins() from HomePage)
refactor and rename moveForClinkOnLink() into moveToJenkinsVersion()
rename WebElement jenkinsLink into jenkinsFooterLink
rename getJenkinsLink() into getJenkinsFooterLink()

[RF] - https://trello.com/c/arVvQIbU